### PR TITLE
To fix a bug with

### DIFF
--- a/src/fobi/admin.py
+++ b/src/fobi/admin.py
@@ -117,7 +117,7 @@ class FormEntryAdmin(admin.ModelAdmin):
     """
     Form entry admin.
     """
-    list_display = ('name', 'slug', 'user', 'is_public', 'created', 'updated',)
+    list_display = ('name', 'slug', 'user', 'is_public', 'created', 'updated', 'is_cloneable',)
     list_editable = ('is_public', 'is_cloneable',)
     list_filter = ('is_public', 'is_cloneable',)
     readonly_fields = ('slug',)


### PR DESCRIPTION
ImproperlyConfigured at /
'FormEntryAdmin.list_editable[1]' refers to 'is_cloneable' which is not defined in 'list_display'.

Somebody obviously forgot that code...