### PR TITLE
Fixes `get_absolute_url()` methods on `FormEntry` and `FormWizardEntry` models

### DIFF
--- a/src/fobi/models.py
+++ b/src/fobi/models.py
@@ -308,7 +308,8 @@ class FormWizardEntry(models.Model):
 
         :return string:
         """
-        return reverse('fobi.form_wizard', kwargs={'slug': self.slug})
+        return reverse('fobi.view_form_wizard_entry',
+                       kwargs={'slug': self.slug})
 
 
 @python_2_unicode_compatible
@@ -383,7 +384,7 @@ class FormEntry(models.Model):
 
         :return string:
         """
-        return reverse('fobi.form_entry', kwargs={'slug': self.slug})
+        return reverse('fobi.view_form_entry', kwargs={'slug': self.slug})
 
 
 class FormWizardFormEntry(models.Model):


### PR DESCRIPTION
Currently, a Django error page is displayed when you click on the 'View on site' links in the Django's admin area. This should fix that, and also enable you to do `{{ object.get_absolute_url }}` in templates to output the 'view' URL for forms and wizards (a DRYer approach).