### PR TITLE
form_handlers.db_store - xlwt export in Python3 broken

### DIFF
--- a/src/fobi/contrib/plugins/form_handlers/db_store/helpers.py
+++ b/src/fobi/contrib/plugins/form_handlers/db_store/helpers.py
@@ -1,5 +1,3 @@
-from __future__ import unicode_literals
-
 import csv
 
 import simplejson as json
@@ -36,6 +34,14 @@ class DataExporter(object):
         """Constructor."""
         self.queryset = queryset
         self.only_args = only_args
+        
+    def _unicode(self, value):
+        """Python 3 compatibility for unicode() function."""
+        try:
+            value = unicode(value)
+        except NameError:
+            pass
+        return value
 
     def _get_initial_response(self, mimetype="application/csv"):
         """Get initial response.
@@ -104,7 +110,7 @@ class DataExporter(object):
         data_values = data_headers.values()
 
         for cell, value in enumerate(data_values):
-            ws.write(row, cell, value, xlwt.easyxf('font: bold on'))
+            ws.write(row, cell, self._unicode(value), xlwt.easyxf('font: bold on'))
             ws.col(cell).width = 256 * 20  # about 20 chars wide
             cell += 1
         row += 1
@@ -112,7 +118,7 @@ class DataExporter(object):
         for obj in self.queryset:
             data = json.loads(obj.saved_data)
             for cell, key in enumerate(data_keys):
-                ws.write(row, cell, data.get(key, ''))
+                ws.write(row, cell, self._unicode(data.get(key, '')))
                 cell += 1
 
             row += 1

--- a/src/fobi/contrib/plugins/form_handlers/db_store/helpers.py
+++ b/src/fobi/contrib/plugins/form_handlers/db_store/helpers.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import csv
 
 import simplejson as json
@@ -102,7 +104,7 @@ class DataExporter(object):
         data_values = data_headers.values()
 
         for cell, value in enumerate(data_values):
-            ws.write(row, cell, unicode(value), xlwt.easyxf('font: bold on'))
+            ws.write(row, cell, value, xlwt.easyxf('font: bold on'))
             ws.col(cell).width = 256 * 20  # about 20 chars wide
             cell += 1
         row += 1
@@ -110,7 +112,7 @@ class DataExporter(object):
         for obj in self.queryset:
             data = json.loads(obj.saved_data)
             for cell, key in enumerate(data_keys):
-                ws.write(row, cell, unicode(data.get(key, '')))
+                ws.write(row, cell, data.get(key, ''))
                 cell += 1
 
             row += 1


### PR DESCRIPTION
Using export to XLS there is an error in Python 3.6.1. Value is typed to unicode which doesn't exists in Python 3.

Error:
```
NameError: name 'unicode' is not defined
```

In file [fobi/contrib/plugins/form_handlers/db_store/helpers.py](https://github.com/barseghyanartur/django-fobi/blob/master/src/fobi/contrib/plugins/form_handlers/db_store/helpers.py):
[Line 105](https://github.com/barseghyanartur/django-fobi/blob/master/src/fobi/contrib/plugins/form_handlers/db_store/helpers.py#L105) : ws.write(row, cell, unicode(value), xlwt.easyxf('font: bold on'))
[Line 113](https://github.com/barseghyanartur/django-fobi/blob/master/src/fobi/contrib/plugins/form_handlers/db_store/helpers.py#L113): ws.write(row, cell, unicode(data.get(key, '')))

I propose using function that tries to do unicode() and catch NameError if it's don't exist. This way we have Python2 and 3 compatibility.