### PR TITLE
allow theme css/js as urls

### DIFF
--- a/src/fobi/base.py
+++ b/src/fobi/base.py
@@ -40,13 +40,13 @@ from .exceptions import (
     ThemeDoesNotExist,
 )
 from .helpers import (
+    absolute_path,
     clean_dict,
     get_form_element_entries_for_form_wizard_entry,
     get_ignorable_form_values,
     map_field_name_to_label,
     safe_text,
     StrippedRequest,
-    uniquify_sequence,
 )
 from .settings import (
     CUSTOM_THEME_DATA,
@@ -638,11 +638,8 @@ class BaseTheme(object):
 
         :return list:
         """
-        media_css = self.media_css[:]
-        if self.plugin_media_css:
-            media_css += self.plugin_media_css
-
-        media_css = uniquify_sequence(media_css)
+        media_css = [absolute_path(css)
+                     for css in set(self.media_css + self.plugin_media_css)]
 
         return media_css
 
@@ -651,11 +648,8 @@ class BaseTheme(object):
 
         :return list:
         """
-        media_js = self.media_js[:]
-        if self.plugin_media_js:
-            media_js += self.plugin_media_js
-
-        media_js = uniquify_sequence(media_js)
+        media_js = [absolute_path(js)
+                    for js in set(self.media_js + self.plugin_media_js)]
 
         return media_js
 

--- a/src/fobi/base.py
+++ b/src/fobi/base.py
@@ -40,13 +40,13 @@ from .exceptions import (
     ThemeDoesNotExist,
 )
 from .helpers import (
-    absolute_path,
     clean_dict,
     get_form_element_entries_for_form_wizard_entry,
     get_ignorable_form_values,
     map_field_name_to_label,
     safe_text,
     StrippedRequest,
+    uniquify_sequence,
 )
 from .settings import (
     CUSTOM_THEME_DATA,
@@ -638,8 +638,7 @@ class BaseTheme(object):
 
         :return list:
         """
-        media_css = [absolute_path(css)
-                     for css in set(self.media_css + self.plugin_media_css)]
+        media_css = uniquify_sequence(self.media_css + self.plugin_media_css)
 
         return media_css
 
@@ -648,8 +647,7 @@ class BaseTheme(object):
 
         :return list:
         """
-        media_js = [absolute_path(js)
-                    for js in set(self.media_js + self.plugin_media_js)]
+        media_js = uniquify_sequence(self.media_js + self.plugin_media_js)
 
         return media_js
 

--- a/src/fobi/helpers.py
+++ b/src/fobi/helpers.py
@@ -18,6 +18,7 @@ from django.contrib.auth.models import AnonymousUser
 from django.core.files.base import File
 # from django.db.utils import DatabaseError
 from django.http import HttpResponse
+from django.templatetags.static import static
 from django.test.client import RequestFactory
 from django.utils.encoding import force_text
 from django.utils.html import format_html_join
@@ -52,6 +53,7 @@ __author__ = 'Artur Barseghyan <artur.barseghyan@gmail.com>'
 __copyright__ = '2014-2017 Artur Barseghyan'
 __license__ = 'GPL 2.0/LGPL 2.1'
 __all__ = (
+    'absolute_path',
     'admin_change_url',
     'clean_dict',
     'clone_file',
@@ -78,7 +80,6 @@ __all__ = (
     'StrippedRequest',
     'StrippedUser',
     'two_dicts_to_string',
-    'uniquify_sequence',
     'update_plugin_data',
     'validate_initial_for_choices',
     'validate_initial_for_multiple_choices',
@@ -188,18 +189,15 @@ def two_dicts_to_string(headers, data, html_element='p'):
 empty_string = text_type('')
 
 
-def uniquify_sequence(sequence):
-    """Uniqify sequence.
-
-    Makes sure items in the given sequence are unique, having the original
-    order preserved.
-
-    :param iterable sequence:
-    :return list:
+def absolute_path(path):
     """
-    seen = set()
-    seen_add = seen.add
-    return [x for x in sequence if x not in seen and not seen_add(x)]
+    Given a relative or absolute path to a static asset, return an absolute
+    path. An absolute path will be returned unchanged while a relative path
+    will be passed to django.templatetags.static.static().
+    """
+    if path.startswith(('http://', 'https://', '/')):
+        return path
+    return static(path)
 
 
 def get_ignorable_form_values():

--- a/src/fobi/helpers.py
+++ b/src/fobi/helpers.py
@@ -53,7 +53,6 @@ __author__ = 'Artur Barseghyan <artur.barseghyan@gmail.com>'
 __copyright__ = '2014-2017 Artur Barseghyan'
 __license__ = 'GPL 2.0/LGPL 2.1'
 __all__ = (
-    'absolute_path',
     'admin_change_url',
     'clean_dict',
     'clone_file',
@@ -80,6 +79,7 @@ __all__ = (
     'StrippedRequest',
     'StrippedUser',
     'two_dicts_to_string',
+    'uniquify_sequence',
     'update_plugin_data',
     'validate_initial_for_choices',
     'validate_initial_for_multiple_choices',
@@ -198,6 +198,21 @@ def absolute_path(path):
     if path.startswith(('http://', 'https://', '/')):
         return path
     return static(path)
+
+
+def uniquify_sequence(sequence):
+    """Uniqify sequence.
+
+    Makes sure items in the given sequence are unique, having the original
+    order preserved.
+
+    :param iterable sequence:
+    :return list:
+    """
+    seen = set()
+    seen_add = seen.add
+    return [absolute_path(x)
+            for x in sequence if x not in seen and not seen_add(x)]
 
 
 def get_ignorable_form_values():

--- a/src/fobi/templates/fobi/generic/_base.html
+++ b/src/fobi/templates/fobi/generic/_base.html
@@ -21,8 +21,8 @@
     {% block theme-stylesheets %}
     {#<!-- This is where stylesheets declared in the Python theme are listed -->#}
 
-    {% for css_file in fobi_theme.get_media_css %}
-    <link href="{% static css_file %}" rel="stylesheet" media="all" />
+    {% for css in fobi_theme.get_media_css %}
+    <link href="{{ css }}" rel="stylesheet" media="all" />
     {% endfor %}
 
     {% endblock theme-stylesheets %}
@@ -189,7 +189,6 @@
     </div><!--/.container-->
     {% endblock main-content-wrapper %}
 
-
   {% endblock main-wrapper %}
 
   {% block javascripts %}
@@ -199,11 +198,10 @@
 
   {% block theme-javascripts %}
     {#<!-- This is where javascripts declared in the Python theme are listed -->#}
-    {% for js_file in fobi_theme.get_media_js %}
-    <script src="{% static js_file %}"></script>
+    {% for js in fobi_theme.get_media_js %}
+    <script src="{{ js }}"></script>
     {% endfor %}
-
   {% endblock theme-javascripts %}
-    
+
   </body>
 </html>


### PR DESCRIPTION
the following patch (based on how django does it) lets me specify css/js resources as urls, not just local files:

```python
class Bootstrap3Theme(BaseTheme):
    """Bootstrap3 theme."""

    uid = UID
    name = _("Bootstrap 3")

    media_css = (
        'https://maxcdn.bootstrapcdn.com/bootstrap/3.3.7/css/bootstrap.min.css',
        'bootstrap3/css/bootstrap3_fobi_extras.css',
        'css/fobi.core.css',
    )
```