### PR TITLE
Change the git remote URL of the wagtail demo submodule to use HTTPS instead of SSH

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "examples/wagtaildemo"]
 	path = examples/wagtaildemo
-	url = git@github.com:barseghyanartur/wagtaildemo.git
+	url = https://github.com/barseghyanartur/wagtaildemo.git


### PR DESCRIPTION
Otherwise automatic deployments (e.g. via `pip install https://github.com/barseghyanartur/django-fobi.git@0.12.12#django-fobi`) would fail to clone the wagtail demo submodule, unless an account-wide read/write SSH key is available to the system account running the deployment. This is undesirable from a
security perspective.

Users could work around this by creating a dummy GitHub account that has no write access to any repo, and add an account-wide SSH key to it, but it's still annoying and means one more thing to maintain.

This change means that you lose the convenience of pushing changes to the wagtail demo right inside the django-fobi repo using SSH key, but I think it's a good trade-off to make automatic deployments easier.

Of course, this doesn't affect users who deploy using the package on pypi. But there are some who prefer to use a particular commit directly in the git repo.