### PR TITLE
unifiy hidden form element html class

### DIFF
--- a/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_properties_snippet.html
+++ b/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_properties_snippet.html
@@ -8,7 +8,7 @@
 
 {% block form_element_wrapper_html_class %}form-group{% endblock %}
 
-{% block hidden_form_element_error_html_class%}has-error{% endblock %}
+{% block form_element_wrapper_error_html_class %}has-error{% endblock %}
 
 {% block form_checkbox_element_field_wrapper_html_class %}col-sm-offset-2 col-sm-9{% endblock %}
 

--- a/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_snippet.html
+++ b/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_snippet.html
@@ -8,7 +8,7 @@
 
 {% block form_element_wrapper_html_class %}form-group{% endblock %}
 
-{% block form_element_wrapper_error_html_class%}has-error{% endblock %}
+{% block form_element_wrapper_error_html_class %}has-error{% endblock %}
 
 {% block form_element_label_html_class %}col-sm-3 control-label{% endblock %}
 
@@ -19,5 +19,3 @@
 {% block form_element_error_html_class %}help-block has-error{% endblock %}
 
 {% block form_element_help_text_html_class %}help-block{% endblock %}
-
-{% block hidden_form_element_wrapper_html_class %}form-group{% endblock %}

--- a/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_wizard_properties_snippet.html
+++ b/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_wizard_properties_snippet.html
@@ -8,8 +8,6 @@
 
 {% block form_element_wrapper_html_class %}form-group{% endblock %}
 
-{% block hidden_form_element_error_html_class%}has-error{% endblock %}
-
 {% block form_checkbox_element_field_wrapper_html_class %}col-sm-offset-2 col-sm-9{% endblock %}
 
 {% block form_element_label_html_class %}col-sm-3 control-label{% endblock %}

--- a/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_wizard_snippet.html
+++ b/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/snippets/form_wizard_snippet.html
@@ -19,5 +19,3 @@
 {% block form_element_error_html_class %}help-block has-error{% endblock %}
 
 {% block form_element_help_text_html_class %}help-block{% endblock %}
-
-{% block hidden_form_element_wrapper_html_class %}form-group{% endblock %}

--- a/src/fobi/contrib/themes/foundation5/templates/foundation5/snippets/form_wizard_snippet.html
+++ b/src/fobi/contrib/themes/foundation5/templates/foundation5/snippets/form_wizard_snippet.html
@@ -19,5 +19,3 @@
 {% block form_element_error_html_class %}help-block has-error{% endblock %}
 
 {% block form_element_help_text_html_class %}help-block{% endblock %}
-
-{% block hidden_form_element_wrapper_html_class %}form-group{% endblock %}

--- a/src/fobi/contrib/themes/simple/templates/simple/snippets/form_wizard_snippet.html
+++ b/src/fobi/contrib/themes/simple/templates/simple/snippets/form_wizard_snippet.html
@@ -19,5 +19,3 @@
 {% block form_element_error_html_class %}help-block has-error{% endblock %}
 
 {% block form_element_help_text_html_class %}help-block{% endblock %}
-
-{% block hidden_form_element_wrapper_html_class %}form-group{% endblock %}

--- a/src/fobi/templates/fobi/generic/snippets/form_snippet.html
+++ b/src/fobi/templates/fobi/generic/snippets/form_snippet.html
@@ -4,18 +4,18 @@
 <div class="{% block form_required_fields_message_wrapper_class %}{% endblock %}">
   {% blocktrans %}Fields marked with <span class="required-field">*</span> are required{% endblocktrans %}
 </div>
-{% endblock form_required_fields_message_block %}
+{% endblock %}
 
 {% block form_non_field_and_hidden_errors %}
 {% get_form_hidden_fields_errors form as form_hidden_fields_errors %}
 {% if form.non_field_errors or form_hidden_fields_errors %}
   {% include fobi_theme.form_non_field_and_hidden_errors_snippet_template %}
 {% endif %}
-{% endblock form_non_field_and_hidden_errors %}
+{% endblock %}
 
 {% for field in form %}
   {% if field.is_hidden %}
-    <div class="{% block hidden_form_element_wrapper_html_class %}hidden{% endblock %}">
+    <div class="{% block form_element_wrapper_hidden_html_class %}hidden{% endblock %}">
       {{ field }}
     </div>
   {% else %}
@@ -26,9 +26,11 @@
       {% endif %}
     {% endspaceless %}">
 
-      <label class="{% block form_element_label_html_class %}{% endblock %}" for="{{ field.id_for_label }}">
-        {{ field.label }}{% if field.field.required %}<span class="{% block form_element_required_field_sign_html_class %}required-field{% endblock %}">*</span>{% endif %}
-      </label>
+      {% if field.label %}
+        <label class="{% block form_element_label_html_class %}{% endblock %}" for="{{ field.id_for_label }}">
+          {{ field.label }}{% if field.field.required %}<span class="{% block form_element_required_field_sign_html_class %}required-field{% endblock %}">*</span>{% endif %}
+        </label>
+      {% endif %}
 
       <div class="{% block form_element_field_wrapper_html_class %}{% endblock %}">
         {% get_form_field_type field as form_field_type %}

--- a/src/fobi/templates/fobi/generic/snippets/form_wizard_properties_snippet.html
+++ b/src/fobi/templates/fobi/generic/snippets/form_wizard_properties_snippet.html
@@ -19,7 +19,7 @@
                     {% get_form_field_type field as field_type %}
                     <div class="{% spaceless %}
                                 {% block form_element_wrapper_html_class %}{% endblock %}
-                                {% if field.errors %} {% block hidden_form_element_error_html_class%}{% endblock %}{% endif %}
+                                {% if field.errors %} {% block form_element_wrapper_error_html_class %}{% endblock %}{% endif %}
                                 {% endspaceless %}">
 
                         {% if field_type.is_checkbox %}

--- a/src/fobi/templates/fobi/generic/snippets/form_wizard_snippet.html
+++ b/src/fobi/templates/fobi/generic/snippets/form_wizard_snippet.html
@@ -18,7 +18,7 @@
             {% for field in form %}
 
                 {% if field.is_hidden %}
-                    <div class="{% block hidden_form_element_wrapper_html_class %}hidden{% endblock %}">{{ field }}</div>
+                    <div class="{% block form_element_wrapper_hidden_html_class %}hidden{% endblock %}">{{ field }}</div>
                 {% else %}
                     <div class="{% spaceless %}
                                 {% block form_element_wrapper_html_class %}form-group{% endblock %}


### PR DESCRIPTION
seems like some templates use `hidden_form_element_wrapper_html_class` and others `form_element_wrapper_hidden_html_class`. unify everywhere to `form_element_wrapper_hidden_html_class`