### PR TITLE
load form media for both create and edit actions

### DIFF
--- a/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/base.html
+++ b/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/base.html
@@ -1,1 +1,15 @@
 {% extends "bootstrap3/_base.html" %}
+
+{% block extrahead %}
+  {{ block.super }}
+  {% if form %}
+    {{ form.media.css }}
+  {% endif %}
+{% endblock extrahead %}
+
+{% block theme-javascripts %}
+  {{ block.super }}
+  {% if form %}
+    {{ form.media.js }}
+  {% endif %}
+{% endblock theme-javascripts %}

--- a/src/fobi/templates/fobi/generic/create_form_entry.html
+++ b/src/fobi/templates/fobi/generic/create_form_entry.html
@@ -4,17 +4,11 @@
 
 {% block page-title %}{% trans "Create form entry" %}{% endblock page-title %}
 
-{% block navbar-menu-content %}
-{% endblock navbar-menu-content %}
-
 {% block navbar-menu-right-content %}
-            <li class="active"><a href="{% url 'fobi.dashboard' %}">{% trans "Forms" %}</a></li>
-            <li><a href="{% url 'fobi.form_wizards_dashboard' %}">{% trans "Wizards" %}</a></li>
+  <li class="active"><a href="{% url 'fobi.dashboard' %}">{% trans "Forms" %}</a></li>
+  <li><a href="{% url 'fobi.form_wizards_dashboard' %}">{% trans "Wizards" %}</a></li>
 {% endblock navbar-menu-right-content %}
 
 {% block content %}
-    {% include fobi_theme.create_form_entry_ajax_template %}
+  {% include fobi_theme.create_form_entry_ajax_template %}
 {% endblock content %}
-
-{% block sidebar-wrapper %}
-{% endblock sidebar-wrapper %}

--- a/src/fobi/templates/fobi/generic/create_form_entry_ajax.html
+++ b/src/fobi/templates/fobi/generic/create_form_entry_ajax.html
@@ -2,8 +2,6 @@
 
 {% load i18n %}
 
-{% block form_page_title %}
-{% trans "Create form" %}
-{% endblock form_page_title %}
+{% block form_page_title %}{% trans "Create form" %}{% endblock form_page_title %}
 
 {% block form_primary_button_text %}{% trans "Add" %}{% endblock %}

--- a/src/fobi/templates/fobi/generic/edit_form_element_entry.html
+++ b/src/fobi/templates/fobi/generic/edit_form_element_entry.html
@@ -4,31 +4,11 @@
 
 {% block page-title %}{% blocktrans with form_element_plugin.name as plugin_name %}Edit "{{ plugin_name }}" element of the form{% endblocktrans %}{% endblock page-title %}
 
-{% block extrahead %}
-    {% if form %}
-        {{ form.media.css }}
-    {% endif %}
-    {{ block.super }}
-{% endblock extrahead %}
-
-{% block navbar-menu-content %}
-{% endblock navbar-menu-content %}
-
 {% block navbar-menu-right-content %}
-            <li class="active"><a href="{% url 'fobi.dashboard' %}">{% trans "Forms" %}</a></li>
-            <li><a href="{% url 'fobi.form_wizards_dashboard' %}">{% trans "Wizards" %}</a></li>
+  <li class="active"><a href="{% url 'fobi.dashboard' %}">{% trans "Forms" %}</a></li>
+  <li><a href="{% url 'fobi.form_wizards_dashboard' %}">{% trans "Wizards" %}</a></li>
 {% endblock navbar-menu-right-content %}
 
 {% block content %}
-    {% include fobi_theme.edit_form_element_entry_ajax_template %}
+  {% include fobi_theme.edit_form_element_entry_ajax_template %}
 {% endblock content %}
-
-{% block sidebar-content %}
-{% endblock sidebar-content %}
-
-{% block theme-javascripts %}
-    {{ block.super }}
-    {% if form %}
-        {{ form.media.js }}
-    {% endif %}
-{% endblock theme-javascripts %}

--- a/src/fobi/templates/fobi/generic/edit_form_entry.html
+++ b/src/fobi/templates/fobi/generic/edit_form_entry.html
@@ -5,34 +5,17 @@
 {% block page-title %}{% trans "Edit form entry" %}{% endblock page-title %}
 
 {% block navbar-menu-right-content %}
-            <li class="active"><a href="{% url 'fobi.dashboard' %}">{% trans "Forms" %}</a></li>
-            <li><a href="{% url 'fobi.form_wizards_dashboard' %}">{% trans "Wizards" %}</a></li>
+   <li class="active"><a href="{% url 'fobi.dashboard' %}">{% trans "Forms" %}</a></li>
+   <li><a href="{% url 'fobi.form_wizards_dashboard' %}">{% trans "Wizards" %}</a></li>
 {% endblock navbar-menu-right-content %}
 
 {% block navbar-menu-content %}
-<li class="active"><a href="{% url 'fobi.edit_form_entry' form_entry.pk %}">{% trans "Edit" %}</a></li>
-<li><a href="{% url 'fobi.view_form_entry' form_entry.slug %}">{% trans "View" %}</a></li>
-{% comment %}
-<li class="dropdown">
-  <a class="dropdown-toggle" data-toggle="dropdown" href="#">
-  {% trans "Your forms" %} <span class="caret"></span>
-  </a>
-  <ul class="dropdown-menu">
-    {% for entry in all_form_entries %}
-    <li>
-      <a href="{% url 'fobi.edit_form_entry' entry.pk %}">{{ entry.name }}</a>
-    </li>
-    {% endfor %}
-  </ul>
-</li>
-{% endcomment %}
+  <li class="active"><a href="{% url 'fobi.edit_form_entry' form_entry.pk %}">{% trans "Edit" %}</a></li>
+  <li><a href="{% url 'fobi.view_form_entry' form_entry.slug %}">{% trans "View" %}</a></li>
 {% endblock navbar-menu-content %}
 
 {% block main-content-inner-attrs %}{% endblock main-content-inner-attrs %}
 
 {% block content-wrapper %}
-    {% include fobi_theme.edit_form_entry_ajax_template %}
+  {% include fobi_theme.edit_form_entry_ajax_template %}
 {% endblock content-wrapper %}
-
-{% block sidebar-wrapper %}
-{% endblock sidebar-wrapper %}


### PR DESCRIPTION
i imagine this fixes only bootstrap3, but the problem is that generic/base.html is not used in this case, which felt like a more natural place to put this.