### PR TITLE
fix form element add dropdown order

### DIFF
--- a/src/fobi/base.py
+++ b/src/fobi/base.py
@@ -8,8 +8,7 @@ import re
 import traceback
 import uuid
 
-
-from collections import defaultdict
+from collections import defaultdict, OrderedDict
 
 import simplejson as json
 
@@ -2814,11 +2813,14 @@ def get_registered_plugins_grouped(registry, sort_items=True):
             registered_plugins[plugin_group] = []
         registered_plugins[plugin_group].append((uid, plugin_name))
 
-    if sort_items:
-        for key, prop in registered_plugins.items():
-            prop.sort()
+    if not sort_items:
+        return registered_plugins
 
-    return registered_plugins
+    ordered_registered_plugins = OrderedDict()
+    for key, prop in sorted(registered_plugins.items()):
+        ordered_registered_plugins[key] = sorted(prop)
+
+    return ordered_registered_plugins
 
 
 def get_registered_plugin_uids(registry, flattern=True, sort_items=True):

--- a/src/fobi/utils.py
+++ b/src/fobi/utils.py
@@ -239,11 +239,14 @@ def get_user_plugins_grouped(get_allowed_plugin_uids_func,
                 registered_plugins[plugin_group] = []
             registered_plugins[plugin_group].append((uid, plugin_name))
 
-    if sort_items:
-        for key, prop in registered_plugins.items():
-            prop.sort()
+    if not sort_items:
+        return registered_plugins
 
-    return registered_plugins
+    ordered_registered_plugins = OrderedDict()
+    for key, prop in sorted(registered_plugins.items()):
+        ordered_registered_plugins[key] = sorted(prop)
+
+    return ordered_registered_plugins
 
 
 def get_user_plugin_uids(get_allowed_plugin_uids_func,

--- a/src/fobi/utils.py
+++ b/src/fobi/utils.py
@@ -6,6 +6,8 @@ import datetime
 import logging
 import os
 
+from collections import OrderedDict
+
 from django.conf import settings
 from django.contrib import messages
 from django.forms.widgets import TextInput


### PR DESCRIPTION
the groups were not sorted and sometimes jumped around.

(i think maybe `SortableDict()` can be retired...)