### PR TITLE
remove duplicate js loading

### DIFF
--- a/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/base.html
+++ b/src/fobi/contrib/themes/bootstrap3/templates/bootstrap3/base.html
@@ -1,15 +1,1 @@
 {% extends "bootstrap3/_base.html" %}
-
-{% block extrahead %}
-  {{ block.super }}
-  {% if form %}
-    {{ form.media.css }}
-  {% endif %}
-{% endblock extrahead %}
-
-{% block theme-javascripts %}
-  {{ block.super }}
-  {% if form %}
-    {{ form.media.js }}
-  {% endif %}
-{% endblock theme-javascripts %}

--- a/src/fobi/templates/fobi/generic/edit_form_entry.html
+++ b/src/fobi/templates/fobi/generic/edit_form_entry.html
@@ -19,3 +19,17 @@
 {% block content-wrapper %}
   {% include fobi_theme.edit_form_entry_ajax_template %}
 {% endblock content-wrapper %}
+
+{% block extra-stylesheets %}
+  {{ block.super }}
+  {% if form %}
+    {{ form.media.css }}
+  {% endif %}
+{% endblock extra-stylesheets %}
+
+{% block theme-javascripts %}
+  {{ block.super }}
+  {% if form %}
+    {{ form.media.js }}
+  {% endif %}
+{% endblock theme-javascripts %}

--- a/src/fobi/templates/fobi/generic/snippets/form_properties_snippet.html
+++ b/src/fobi/templates/fobi/generic/snippets/form_properties_snippet.html
@@ -63,10 +63,3 @@
     </div>
   {% endif %}
 {% endfor %}
-
-{% if form.media.js %}
-  {% block javascripts %}
-    {{ block.super }}
-    {{ form.media.js }}
-  {% endblock javascripts %}
-{% endif %}


### PR DESCRIPTION
JS was still loaded 2x when editing the form itself (not a form element).
this is a better solution for all themes.