### PR TITLE
chagned a ref from kwargs to qs_kwargs, so is_public is applied to query

### DIFF
--- a/src/fobi/views.py
+++ b/src/fobi/views.py
@@ -1468,7 +1468,7 @@ class FormWizardView(DynamicSessionWizardView):
         try:
             qs_kwargs = {'slug': kwargs.get('form_wizard_entry_slug')}
             if not user_is_authenticated:
-                kwargs.update({'is_public': True})
+                qs_kwargs.update({'is_public': True})
             form_wizard_entry = FormWizardEntry.objects \
                 .select_related('user') \
                 .get(**qs_kwargs)


### PR DESCRIPTION
i noticed you were just throwing away the `is_public` value here, by adding to kwargs and then not using it, looks like you wanted to apply it to the queryset that you are grabbing on the next line.... 