### PR TITLE
PY2: Encoding issue with file attachements in mail handler

### DIFF
--- a/src/fobi/contrib/plugins/form_handlers/mail/mixins.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail/mixins.py
@@ -1,3 +1,4 @@
+# -*- coding: utf-8 -*-
 from __future__ import absolute_import, unicode_literals
 
 import datetime
@@ -112,7 +113,7 @@ class MailHandlerMixin(object):
                 if PY3:
                     imf_chunks = b''.join([c for c in imf.chunks()])
                 else:
-                    imf_chunks = ''.join([c for c in imf.chunks()])
+                    imf_chunks = str('').join([c for c in imf.chunks()])
                 files[field_name] = (
                     imf.name,
                     imf_chunks,


### PR DESCRIPTION
No mail is sent when a form contains a filled FileField.