### PR TITLE
Make fobi wagtail integration work with wagtail 2

### DIFF
--- a/src/fobi/contrib/apps/wagtail_integration/abstract.py
+++ b/src/fobi/contrib/apps/wagtail_integration/abstract.py
@@ -8,8 +8,12 @@ from django.utils.translation import ugettext_lazy as _
 
 from fobi.integration.processors import IntegrationProcessor
 
-from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
-from wagtail.wagtailcore.models import Page
+try:
+    from wagtail.wagtailadmin.edit_handlers import FieldPanel, MultiFieldPanel
+    from wagtail.wagtailcore.models import Page
+except ImportError: # since wagtail 2.x changes
+    from wagtail.admin.edit_handlers import FieldPanel, MultiFieldPanel
+    from wagtail.core.models import Page
 
 from .helpers import (
     get_form_template_choices,


### PR DESCRIPTION
As far as I test it, it works, but I still have an error about `DJANGO_GTE_1_11` not found even if `django-ǹine` is install. If you have an idea, let me know.