### PR TITLE
Add an parameter in `SampleMailHandlerPlugin.run`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -695,7 +695,7 @@ Defining the Sample mail handler plugin.
         name = _("Sample mail")
         form = SampleMailForm
 
-        def run(self, form_entry, request, form):
+        def run(self, form_entry, request, form, form_element_entries=None):
             """To be executed by handler."""
             send_mail(
                 self.data.subject,


### PR DESCRIPTION
Fix this error in `README.rst` showing an example for: "Creating a new form
handler plugin"

```
Error occurred: (
    <my_fobi_mailer.fobi_form_handlers.SampleMailHandlerPlugin\
         object at 0x7fce7e34c908>,
    TypeError('run() takes 4 positional arguments but 5 were given',)
).
```