### PR TITLE
Form data loss when uploading files with accentuated names

### DIFF
--- a/src/fobi/contrib/plugins/form_elements/fields/file/base.py
+++ b/src/fobi/contrib/plugins/form_elements/fields/file/base.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import
+from __future__ import unicode_literals
 
 import os
 

--- a/src/fobi/contrib/plugins/form_handlers/db_store/admin.py
+++ b/src/fobi/contrib/plugins/form_handlers/db_store/admin.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 from django.conf import settings
 from django.contrib import admin
 from django.utils.translation import ugettext_lazy as _

--- a/src/fobi/contrib/plugins/form_handlers/db_store/models.py
+++ b/src/fobi/contrib/plugins/form_handlers/db_store/models.py
@@ -1,3 +1,5 @@
+from __future__ import unicode_literals
+
 import bleach
 import simplejson as json
 from six import python_2_unicode_compatible, string_types


### PR DESCRIPTION
On python2.7, uploading files with accentuated names on a form where a `db_store` handler is used,  fails silently (success page is displayed to the user), stops the execution of other handlers and causes the loss of user's data.

The pull request prevents the raise of UnicodeEncodeError.