### PR TITLE
removed unicode_to_repr function, not supported in rest_framework anymore

### DIFF
--- a/src/fobi/contrib/apps/drf_integration/dynamic.py
+++ b/src/fobi/contrib/apps/drf_integration/dynamic.py
@@ -7,7 +7,6 @@ from django.core.exceptions import ValidationError as DjangoValidationError
 from django.utils.functional import cached_property
 from django.utils.translation import ugettext_lazy as _
 
-from rest_framework.compat import unicode_to_repr
 from rest_framework.exceptions import ErrorDetail, ValidationError
 from rest_framework.fields import (
     empty,
@@ -448,8 +447,7 @@ def assemble_serializer_class(form_entry,
             return attrs
 
         def __repr__(self):
-            return unicode_to_repr(
-                representation.serializer_repr(self, indent=1))
+            return representation.serializer_repr(self, indent=1)
 
         # The following are used for accessing `BoundField` instances on the
         # serializer, for the purposes of presenting a form-like API onto the


### PR DESCRIPTION
The error `ImportError: cannot import name 'unicode_to_repr'` occurs when following import is executed: `    from fobi.contrib.apps.drf_integration.urls import fobi_router`. The `unicode_to_repr` function was removed from compat module when python 2 compatibility was dropped in django-rest-framework (see [here](https://github.com/encode/django-rest-framework/pull/6615)). I am using python 3.5.3, django 2.0.13 and django-rest-framework 3.10.1.

Please review the fix and let's see if everything is okay.