### PR TITLE
Update index.rst: fix context processor path 

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -322,7 +322,7 @@ And ``fobi.context_processors.theme`` and
         },
     ]
 
-Make sure that ``django.core.context_processors.request`` is in
+Make sure that ``django.template.context_processors.request`` is in
 ``context_processors`` too.
 
 (4) Configure URLs


### PR DESCRIPTION
django.core.context_processors:
Built-in template context processors have been moved to django.template.context_processors.
Source: https://docs.djangoproject.com/en/dev/releases/1.8/#django-core-context-processors