### PR TITLE
Incorrect urls for files in emails

### DIFF
--- a/src/fobi/contrib/plugins/form_handlers/mail/base.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail/base.py
@@ -154,7 +154,8 @@ class MailWizardHandlerPlugin(FormWizardHandlerPlugin):
         rendered_data = []
         for key, value in cleaned_data.items():
             if value and isinstance(value, string_types) \
-                     and value.startswith(settings.MEDIA_URL):
+                     and value.startswith(settings.MEDIA_URL) \
+                     and not value.startswith("http"):
                 cleaned_data[key] = '{base_url}{value}'.format(
                     base_url=base_url, value=value
                 )

--- a/src/fobi/contrib/plugins/form_handlers/mail/mixins.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail/mixins.py
@@ -53,7 +53,8 @@ class MailHandlerMixin(object):
         for key, value in cleaned_data.items():
             if value:
                 if isinstance(value, string_types) \
-                        and value.startswith(settings.MEDIA_URL):
+                    and value.startswith(settings.MEDIA_URL) \
+                    and not value.startswith("http"):
                     cleaned_data[key] = '{base_url}{value}'.format(
                         base_url=base_url, value=value
                     )

--- a/src/fobi/contrib/plugins/form_handlers/mail_sender/base.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail_sender/base.py
@@ -144,7 +144,8 @@ class MailSenderWizardHandlerPlugin(FormWizardHandlerPlugin):
         rendered_data = []
         for key, value in cleaned_data.items():
             if value and isinstance(value, string_types) \
-                     and value.startswith(settings.MEDIA_URL):
+                     and value.startswith(settings.MEDIA_URL) \
+                     and not value.startswith("http"):
                 cleaned_data[key] = '{base_url}{value}'.format(
                     base_url=base_url, value=value
                 )

--- a/src/fobi/contrib/plugins/form_handlers/mail_sender/mixins.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail_sender/mixins.py
@@ -52,7 +52,8 @@ class MailSenderHandlerMixin(object):
         for key, value in cleaned_data.items():
             if value:
                 if isinstance(value, string_types) \
-                        and value.startswith(settings.MEDIA_URL):
+                    and value.startswith(settings.MEDIA_URL) \
+                    and not value.startswith("http"):
                     cleaned_data[key] = '{base_url}{value}'.format(
                         base_url=base_url, value=value
                     )


### PR DESCRIPTION
The bug is triggered when using a full url in `settings.MEDIA_URL`
instead of only a folder name.

The previous check would add `base_url` before our
`settings.MEDIA_URL` if our url started with `settings.MEDIA_URL`,
and now it add it only if our url don't start with "http" (prevent
adding "https://example.ext" before "https://media-example.ext").