### PR TITLE
FIX: incorrect urls for files in emails

### DIFF
--- a/src/fobi/contrib/plugins/form_handlers/mail/base.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail/base.py
@@ -156,6 +156,7 @@ class MailWizardHandlerPlugin(FormWizardHandlerPlugin):
                 value
                 and isinstance(value, string_types)
                 and value.startswith(settings.MEDIA_URL)
+                and not value.startswith("http")
             ):
                 cleaned_data[key] = "{base_url}{value}".format(
                     base_url=base_url, value=value

--- a/src/fobi/contrib/plugins/form_handlers/mail/mixins.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail/mixins.py
@@ -46,8 +46,10 @@ class MailHandlerMixin(object):
         rendered_data = []
         for key, value in cleaned_data.items():
             if value:
-                if isinstance(value, string_types) and value.startswith(
-                    settings.MEDIA_URL
+                if (
+                    isinstance(value, string_types)
+                    and value.startswith(settings.MEDIA_URL)
+                    and not value.startswith("http")
                 ):
                     cleaned_data[key] = "{base_url}{value}".format(
                         base_url=base_url, value=value

--- a/src/fobi/contrib/plugins/form_handlers/mail_sender/base.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail_sender/base.py
@@ -146,6 +146,7 @@ class MailSenderWizardHandlerPlugin(FormWizardHandlerPlugin):
                 value
                 and isinstance(value, string_types)
                 and value.startswith(settings.MEDIA_URL)
+                and not value.startswith("http")
             ):
                 cleaned_data[key] = "{base_url}{value}".format(
                     base_url=base_url, value=value

--- a/src/fobi/contrib/plugins/form_handlers/mail_sender/mixins.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail_sender/mixins.py
@@ -45,8 +45,10 @@ class MailSenderHandlerMixin(object):
         rendered_data = []
         for key, value in cleaned_data.items():
             if value:
-                if isinstance(value, string_types) and value.startswith(
-                    settings.MEDIA_URL
+                if (
+                    isinstance(value, string_types)
+                    and value.startswith(settings.MEDIA_URL)
+                    and not value.startswith("http")
                 ):
                     cleaned_data[key] = "{base_url}{value}".format(
                         base_url=base_url, value=value


### PR DESCRIPTION
PR made following [this conversation](https://github.com/barseghyanartur/django-fobi/pull/264#issuecomment-1352829756) in a previous PR.

----

The bug was triggered when using a full url in settings.MEDIA_URL instead of only a folder name.

The previous check would add base_url before our settings.MEDIA_URL if our url started with settings.MEDIA_URL, and now it adds it only if our url don't start with "http" (prevent adding "https://example.ext" before "https://media-example.ext").