### PR TITLE
form_handlers.db_store return created SavedFormDataEntry

### DIFF
--- a/src/fobi/contrib/plugins/form_handlers/db_store/base.py
+++ b/src/fobi/contrib/plugins/form_handlers/db_store/base.py
@@ -50,15 +50,16 @@ class DBStoreHandlerPlugin(FormHandlerPlugin):
         :param django.forms.Form form:
         :param iterable form_element_entries: Iterable of
             ``fobi.models.FormElementEntry`` objects.
+        :return True, instance of ``fobi.contrib.plugins.form_handler.db_store.models.SavedFormDataEntry`` with saved data.
         """
         # Clean up the values, leave our content fields and empty values.
         field_name_to_label_map, cleaned_data = get_processed_form_data(
             form, form_element_entries
         )
 
-        self.save_form_data_entry(
+        return (True, self.save_form_data_entry(
             form_entry, request, field_name_to_label_map, cleaned_data
-        )
+        ))
 
     def save_form_data_entry(
         self, form_entry, request, field_name_to_label_map, cleaned_data
@@ -82,6 +83,7 @@ class DBStoreHandlerPlugin(FormHandlerPlugin):
             saved_data=json.dumps(cleaned_data, cls=DjangoJSONEncoder),
         )
         saved_form_data_entry.save()
+        return saved_form_data_entry
 
     def custom_actions(self, form_entry, request=None):
         """Custom actions.


### PR DESCRIPTION
## Description
This small merge request changes `form_handlers.db_store.run` and `form_handlers.db_store.save_form_data_entry`.
It changes `form_handlers.db_store.run` return signature:
```
from None to (True, instance of fobi.contrib.plugins.form_handler.db_store.models.SavedFormDataEntry)
```

## The reason I want this
I have a booking, which customers can make using an 'intake form'.
It looks like:
```python
class Booking(models.Model):
    primary_key = models.CharField(primary_key=True, max_length=idgen_len, default=idgen)
    customer = models.ForeignKey(Customer, on_delete=models.CASCADE, related_name='customer')
    form = models.ForeignKey(SavedFormDataEntry, on_delete=models.CASCADE, related_name='form')
    event_type = models.ForeignKey(EventType, on_delete=models.CASCADE, related_name='event_type')
    # ... other fields
```

I store the forms using this `db_store` plugin, and want to reference them.
With the changes, I can do this:
```python
success, saved_form_data_entry = dbstorehandler_plugin._run(form_entry, request, form, form_element_entries)
Booking(
    customer = customer,
    form = saved_form_data_entry,
    event_type = event_type,
    # other fields...
)```
