### PR TITLE
Except for formelements all __init__.py are changed so that Django 4.1 gives less warnings for default_app_config

### DIFF
--- a/src/fobi/__init__.py
+++ b/src/fobi/__init__.py
@@ -4,4 +4,5 @@ __author__ = "Artur Barseghyan <artur.barseghyan@gmail.com>"
 __copyright__ = "2014-2022 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 
-default_app_config = "fobi.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.apps.Config"

--- a/src/fobi/contrib/apps/djangocms_integration/__init__.py
+++ b/src/fobi/contrib/apps/djangocms_integration/__init__.py
@@ -4,4 +4,5 @@ __copyright__ = "2014-2019 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config",)
 
-default_app_config = "fobi.contrib.apps.djangocms_integration.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.apps.djangocms_integration.apps.Config"

--- a/src/fobi/contrib/apps/drf_integration/__init__.py
+++ b/src/fobi/contrib/apps/drf_integration/__init__.py
@@ -4,6 +4,8 @@ __copyright__ = "2016-2019 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config",)
 
-default_app_config = "fobi.contrib.apps.drf_integration.apps.Config"
+
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.apps.drf_integration.apps.Config"
 
 UID = "drf_integration"

--- a/src/fobi/contrib/apps/feincms_integration/__init__.py
+++ b/src/fobi/contrib/apps/feincms_integration/__init__.py
@@ -4,4 +4,6 @@ __copyright__ = "2014-2019 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config",)
 
-default_app_config = "fobi.contrib.apps.feincms_integration.apps.Config"
+
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.apps.feincms_integration.apps.Config"

--- a/src/fobi/contrib/apps/mezzanine_integration/__init__.py
+++ b/src/fobi/contrib/apps/mezzanine_integration/__init__.py
@@ -4,4 +4,5 @@ __copyright__ = "2014-2019 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config",)
 
-default_app_config = "fobi.contrib.apps.mezzanine_integration.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.apps.mezzanine_integration.apps.Config"

--- a/src/fobi/contrib/apps/wagtail_integration/__init__.py
+++ b/src/fobi/contrib/apps/wagtail_integration/__init__.py
@@ -4,4 +4,5 @@ __copyright__ = "2014-2019 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config",)
 
-default_app_config = "fobi.contrib.apps.wagtail_integration.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.apps.wagtail_integration.apps.Config"

--- a/src/fobi/contrib/plugins/form_elements/content/content_image/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/content/content_image/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.content." "content_image.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.content." "content_image.apps.Config"
+    )
 
 UID = "content_image"

--- a/src/fobi/contrib/plugins/form_elements/content/content_image_url/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/content/content_image_url/__init__.py
@@ -6,10 +6,10 @@ __all__ = (
     "default_app_config",
     "UID",
 )
-
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.content."
-    "content_image_url.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.content."
+        "content_image_url.apps.Config"
+    )
 
 UID = "content_image_url"

--- a/src/fobi/contrib/plugins/form_elements/content/content_markdown/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/content/content_markdown/__init__.py
@@ -4,8 +4,9 @@ __copyright__ = "2014-2019 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config", "UID")
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.content." "content_markdown.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.content." "content_markdown.apps.Config"
+    )
 
 UID = "content_markdown"

--- a/src/fobi/contrib/plugins/form_elements/content/content_richtext/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/content/content_richtext/__init__.py
@@ -4,8 +4,9 @@ __copyright__ = "RIPE NCC"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config", "UID")
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.content." "content_richtext.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.content." "content_richtext.apps.Config"
+    )
 
 UID = "content_richtext"

--- a/src/fobi/contrib/plugins/form_elements/content/content_text/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/content/content_text/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.content." "content_text.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.content." "content_text.apps.Config"
+    )
 
 UID = "content_text"

--- a/src/fobi/contrib/plugins/form_elements/content/content_video/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/content/content_video/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.content." "content_video.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.content." "content_video.apps.Config"
+    )
 
 UID = "content_video"

--- a/src/fobi/contrib/plugins/form_elements/security/captcha/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/security/captcha/__init__.py
@@ -6,9 +6,9 @@ __all__ = (
     "default_app_config",
     "UID",
 )
-
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.security." "captcha.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.security." "captcha.apps.Config"
+    )
 
 UID = "captcha"

--- a/src/fobi/contrib/plugins/form_elements/security/honeypot/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/security/honeypot/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.security." "honeypot.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.security." "honeypot.apps.Config"
+    )
 
 UID = "honeypot"

--- a/src/fobi/contrib/plugins/form_elements/security/invisible_recaptcha/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/security/invisible_recaptcha/__init__.py
@@ -6,10 +6,10 @@ __all__ = (
     "default_app_config",
     "UID",
 )
-
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.security."
-    "invisible_recaptcha.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.security."
+        "invisible_recaptcha.apps.Config"
+    )
 
 UID = "invisible_recaptcha"

--- a/src/fobi/contrib/plugins/form_elements/security/recaptcha/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/security/recaptcha/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.security." "recaptcha.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.security." "recaptcha.apps.Config"
+    )
 
 UID = "recaptcha"

--- a/src/fobi/contrib/plugins/form_elements/test/dummy/__init__.py
+++ b/src/fobi/contrib/plugins/form_elements/test/dummy/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_elements.test." "dummy.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_elements.test." "dummy.apps.Config"
+    )
 
 UID = "dummy"

--- a/src/fobi/contrib/plugins/form_handlers/db_store/__init__.py
+++ b/src/fobi/contrib/plugins/form_handlers/db_store/__init__.py
@@ -7,6 +7,7 @@ __all__ = (
     "UID",
 )
 
-default_app_config = "fobi.contrib.plugins.form_handlers.db_store.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.plugins.form_handlers.db_store.apps.Config"
 
 UID = "db_store"

--- a/src/fobi/contrib/plugins/form_handlers/http_repost/__init__.py
+++ b/src/fobi/contrib/plugins/form_handlers/http_repost/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_handlers." "http_repost.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_handlers." "http_repost.apps.Config"
+    )
 
 UID = "http_repost"

--- a/src/fobi/contrib/plugins/form_handlers/mail/__init__.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail/__init__.py
@@ -9,6 +9,7 @@ __all__ = (
     "UID",
 )
 
-default_app_config = "fobi.contrib.plugins.form_handlers.mail.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.plugins.form_handlers.mail.apps.Config"
 
 UID = "mail"

--- a/src/fobi/contrib/plugins/form_handlers/mail_sender/__init__.py
+++ b/src/fobi/contrib/plugins/form_handlers/mail_sender/__init__.py
@@ -9,8 +9,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_handlers.mail_sender.apps." "Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_handlers.mail_sender.apps." "Config"
+    )
 
 UID = "mail_sender"

--- a/src/fobi/contrib/plugins/form_importers/mailchimp_importer/__init__.py
+++ b/src/fobi/contrib/plugins/form_importers/mailchimp_importer/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.plugins.form_importers." "mailchimp_importer.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.plugins.form_importers." "mailchimp_importer.apps.Config"
+    )
 
 UID = "mailchimp"

--- a/src/fobi/contrib/themes/bootstrap3/__init__.py
+++ b/src/fobi/contrib/themes/bootstrap3/__init__.py
@@ -7,6 +7,7 @@ __all__ = (
     "UID",
 )
 
-default_app_config = "fobi.contrib.themes.bootstrap3.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.themes.bootstrap3.apps.Config"
 
 UID = "bootstrap3"

--- a/src/fobi/contrib/themes/djangocms_admin_style_theme/__init__.py
+++ b/src/fobi/contrib/themes/djangocms_admin_style_theme/__init__.py
@@ -7,8 +7,9 @@ __all__ = (
     "UID",
 )
 
-default_app_config = (
-    "fobi.contrib.themes." "djangocms_admin_style_theme.apps.Config"
-)
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = (
+        "fobi.contrib.themes." "djangocms_admin_style_theme.apps.Config"
+    )
 
 UID = "djangocms_admin_style_theme"

--- a/src/fobi/contrib/themes/foundation5/__init__.py
+++ b/src/fobi/contrib/themes/foundation5/__init__.py
@@ -4,6 +4,7 @@ __copyright__ = "2014-2019 Artur Barseghyan"
 __license__ = "GPL 2.0/LGPL 2.1"
 __all__ = ("default_app_config",)
 
-default_app_config = "fobi.contrib.themes.foundation5.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.themes.foundation5.apps.Config"
 
 UID = "foundation5"

--- a/src/fobi/contrib/themes/simple/__init__.py
+++ b/src/fobi/contrib/themes/simple/__init__.py
@@ -7,6 +7,7 @@ __all__ = (
     "UID",
 )
 
-default_app_config = "fobi.contrib.themes.simple.apps.Config"
+if django.VERSION < (3, 2): # pragma: no cover
+    default_app_config = "fobi.contrib.themes.simple.apps.Config"
 
 UID = "simple"


### PR DESCRIPTION
Example code:

if django.VERSION < (3, 2): # pragma: no cover
    default_app_config = "fobi.apps.Config"

